### PR TITLE
leverage ByteSize

### DIFF
--- a/src/tensorshare/schema.py
+++ b/src/tensorshare/schema.py
@@ -21,3 +21,8 @@ class TensorShare(BaseModel):
         },
         ser_json_bytes="base64",
     )
+
+    @property
+    def size_as_str(self) -> str:
+        """Return size as a string in human readable format."""
+        return self.size.human_readable()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 """Fixture stores for the testing suite."""
 
+import random
+
 import jax.numpy as jnp
 import numpy as np
 import paddle
@@ -7,6 +9,22 @@ import pytest
 
 # import tensorflow as tf
 import torch
+
+from tensorshare.converter.utils import convert_numpy_to_safetensors
+
+
+@pytest.fixture
+def converted_fixed_numpy_tensors() -> bytes:
+    """Return a serialized numpy tensor."""
+    _tensor = {"embeddings": np.zeros((2, 2))}
+    return convert_numpy_to_safetensors(_tensor)
+
+
+@pytest.fixture
+def random_fp32_numpy_tensors() -> bytes:
+    """Return a serialized numpy tensor."""
+    shape = (random.randint(1, 100), random.randint(1, 100))
+    return {"embeddings": np.random.random(shape)}
 
 
 @pytest.fixture

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,6 +1,7 @@
 """Tests for the pydantic schemas of tensorshare."""
 
 import pytest
+from pydantic import ByteSize
 
 from tensorshare.converter.utils import (
     convert_flax_to_safetensors,
@@ -15,9 +16,47 @@ from tensorshare.schema import TensorShare
 class TestTensorShare:
     """Tests for the pydantic schemas of tensorshare."""
 
-    def test_tensorshare_pydantic_schema(self) -> None:
+    @pytest.mark.usefixtures("converted_fixed_numpy_tensors")
+    def test_tensorshare_pydantic_schema_with_fixed_tensor(
+        self, converted_fixed_numpy_tensors
+    ) -> None:
         """Test the pydantic schema of tensorshare."""
-        # TODO: Check the TensorShare pydantic schema and its model_config
+        tensorshare = TensorShare(
+            tensors=converted_fixed_numpy_tensors,
+            size=len(converted_fixed_numpy_tensors),
+        )
+
+        assert isinstance(tensorshare.tensors, bytes)
+        assert isinstance(tensorshare.size, int)
+
+        assert isinstance(tensorshare.size_as_str, str)
+        assert tensorshare.size_as_str == "112B"
+
+        assert (
+            tensorshare.model_dump_json(indent=4)
+            == '{\n    "tensors":'
+            ' "SAAAAAAAAAB7ImVtYmVkZGluZ3MiOnsiZHR5cGUiOiJGNjQiLCJzaGFwZSI6WzIsMl0sImRhdGFfb2Zmc2V0cyI6WzAsMzJdfX0gICAgICAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",\n'
+            '    "size": 112\n}'
+        )
+
+    @pytest.mark.usefixtures("random_fp32_numpy_tensors")
+    def test_tensorshare_pydantic_schema_with_random_tensor(
+        self, random_fp32_numpy_tensors
+    ) -> None:
+        """Test the pydantic schema of tensorshare."""
+        converted_tensors = convert_numpy_to_safetensors(random_fp32_numpy_tensors)
+
+        tensorshare = TensorShare(
+            tensors=converted_tensors,
+            size=len(converted_tensors),
+        )
+
+        assert tensorshare.tensors == converted_tensors
+        assert tensorshare.size == len(converted_tensors)
+
+        assert (
+            tensorshare.size_as_str == ByteSize(len(converted_tensors)).human_readable()
+        )
 
     @pytest.mark.usefixtures("dict_zeros_flax_tensor")
     def test_tensorshare_with_flax(self, dict_zeros_flax_tensor) -> None:


### PR DESCRIPTION
This PR implements a method to get an human readable version of the size of the tensors in the TensorShare schema.