### PR TITLE
TensorShare.to_tensors method

### DIFF
--- a/src/tensorshare/schema.py
+++ b/src/tensorshare/schema.py
@@ -40,8 +40,9 @@ class TensorShare(BaseModel):
         """Return size as a string in human readable format."""
         return self.size.human_readable()
 
-    @staticmethod
+    @classmethod
     def from_dict(
+        cls,
         tensors: Dict[str, Union[Array, np.ndarray, paddle.Tensor, torch.Tensor]],
         metadata: Optional[Dict[str, str]] = None,
         backend: Optional[Union[str, Backend]] = None,
@@ -70,4 +71,24 @@ class TensorShare(BaseModel):
             tensors=tensors, metadata=metadata, backend=backend
         )
 
-        return TensorShare(tensors=_tensors, size=size)
+        return cls(tensors=_tensors, size=size)
+
+    def to_tensors(
+        self,
+        backend: Union[str, Backend],
+    ) -> Dict[str, Union[Array, np.ndarray, paddle.Tensor, torch.Tensor]]:
+        """
+        Convert a TensorShare object to a dictionary of tensors in the specified backend.
+
+        Args:
+            backend (Union[str, Backend]): Backend to use for the conversion.
+
+        Raises:
+            TypeError: If backend is not a string or an instance of Backend enum.
+            ValueError: If backend is not supported.
+
+        Returns:
+            Dict[str, Union[Array, np.ndarray, paddle.Tensor, torch.Tensor]]:
+                Tensors stored in a dictionary with their name as key in the specified backend.
+        """
+        return TensorProcessor.deserialize(self.tensors, backend=backend)

--- a/tests/serialization/test_processor.py
+++ b/tests/serialization/test_processor.py
@@ -125,18 +125,7 @@ class TestTensorProcessorSerialize:
             TensorProcessor.serialize(tensors)
 
     @pytest.mark.usefixtures("multiple_flax_tensors")
-    def test_tensor_processor_serialize_with_multiple_flax_tensors(
-        self, multiple_flax_tensors
-    ) -> None:
-        """Test the serialize function with multiple flax tensors."""
-        tensorshare = TensorProcessor.serialize(multiple_flax_tensors)
-
-        assert isinstance(tensorshare, tuple)
-        assert isinstance(tensorshare[0], bytes)
-        assert isinstance(tensorshare[1], int)
-
-    @pytest.mark.usefixtures("multiple_flax_tensors")
-    @pytest.mark.parametrize("backend", [Backend.FLAX, "flax"])
+    @pytest.mark.parametrize("backend", [None, Backend.FLAX, "flax"])
     def test_tensor_processor_serialize_with_multiple_flax_tensors_and_backend(
         self, multiple_flax_tensors, backend
     ) -> None:
@@ -148,18 +137,7 @@ class TestTensorProcessorSerialize:
         assert isinstance(tensorshare[1], int)
 
     @pytest.mark.usefixtures("multiple_numpy_tensors")
-    def test_tensor_processor_serialize_with_multiple_numpy_tensors(
-        self, multiple_numpy_tensors
-    ) -> None:
-        """Test the serialize function with multiple numpy tensors."""
-        tensorshare = TensorProcessor.serialize(multiple_numpy_tensors)
-
-        assert isinstance(tensorshare, tuple)
-        assert isinstance(tensorshare[0], bytes)
-        assert isinstance(tensorshare[1], int)
-
-    @pytest.mark.usefixtures("multiple_numpy_tensors")
-    @pytest.mark.parametrize("backend", [Backend.NUMPY, "numpy"])
+    @pytest.mark.parametrize("backend", [None, Backend.NUMPY, "numpy"])
     def test_tensor_processor_serialize_with_multiple_numpy_tensors_and_backend(
         self, multiple_numpy_tensors, backend
     ) -> None:
@@ -171,18 +149,7 @@ class TestTensorProcessorSerialize:
         assert isinstance(tensorshare[1], int)
 
     @pytest.mark.usefixtures("multiple_paddle_tensors")
-    def test_tensor_processor_serialize_with_multiple_paddle_tensors(
-        self, multiple_paddle_tensors
-    ) -> None:
-        """Test the serialize function with multiple paddle tensors."""
-        tensorshare = TensorProcessor.serialize(multiple_paddle_tensors)
-
-        assert isinstance(tensorshare, tuple)
-        assert isinstance(tensorshare[0], bytes)
-        assert isinstance(tensorshare[1], int)
-
-    @pytest.mark.usefixtures("multiple_paddle_tensors")
-    @pytest.mark.parametrize("backend", [Backend.PADDLEPADDLE, "paddlepaddle"])
+    @pytest.mark.parametrize("backend", [None, Backend.PADDLEPADDLE, "paddlepaddle"])
     def test_tensor_processor_serialize_with_multiple_paddle_tensors_and_backend(
         self, multiple_paddle_tensors, backend
     ) -> None:
@@ -196,16 +163,7 @@ class TestTensorProcessorSerialize:
         assert isinstance(tensorshare[1], int)
 
     # @pytest.mark.usefixtures("multiple_tensorflow_tensors")
-    # def test_tensor_processor_serialize_with_multiple_tensorflow_tensors(self, multiple_tensorflow_tensors) -> None:
-    #     """Test the serialize function with multiple tensorflow tensors."""
-    #     tensorshare = TensorProcessor.serialize(multiple_tensorflow_tensors)
-
-    #     assert isinstance(tensorshare, tuple)
-    #     assert isinstance(tensorshare[0], bytes)
-    #     assert isinstance(tensorshare[1], int)
-
-    # @pytest.mark.usefixtures("multiple_tensorflow_tensors")
-    # @parametrize("backend", [Backend.TENSORFLOW, "tensorflow"])
+    # @parametrize("backend", [None, Backend.TENSORFLOW, "tensorflow"])
     # def test_tensor_processor_serialize_with_multiple_tensorflow_tensors_and_backend(
     #     self, multiple_tensorflow_tensors, backend
     # ) -> None:
@@ -217,18 +175,7 @@ class TestTensorProcessorSerialize:
     # assert isinstance(tensorshare[1], int)
 
     @pytest.mark.usefixtures("multiple_torch_tensors")
-    def test_tensor_processor_serialize_with_multiple_torch_tensors(
-        self, multiple_torch_tensors
-    ) -> None:
-        """Test the serialize function with multiple torch tensors."""
-        tensorshare = TensorProcessor.serialize(multiple_torch_tensors)
-
-        assert isinstance(tensorshare, tuple)
-        assert isinstance(tensorshare[0], bytes)
-        assert isinstance(tensorshare[1], int)
-
-    @pytest.mark.usefixtures("multiple_torch_tensors")
-    @pytest.mark.parametrize("backend", [Backend.TORCH, "torch"])
+    @pytest.mark.parametrize("backend", [None, Backend.TORCH, "torch"])
     def test_tensor_processor_serialize_with_multiple_torch_tensors_and_backend(
         self, multiple_torch_tensors, backend
     ) -> None:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,12 +1,13 @@
 """Tests for the pydantic schemas of tensorshare."""
 
-import pytest
-from pydantic import ByteSize
 import jax.numpy as jnp
 import numpy as np
 import paddle
+import pytest
+
 # import tensorflow as tf
 import torch
+from pydantic import ByteSize
 
 from tensorshare.schema import TensorShare
 from tensorshare.serialization.constants import Backend
@@ -172,7 +173,9 @@ class TestTensorShare:
 
     @pytest.mark.usefixtures("dict_zeros_numpy_tensor")
     @pytest.mark.parametrize("backend", [None, Backend.NUMPY, "numpy"])
-    def test_from_dict_method_with_numpy(self, dict_zeros_numpy_tensor, backend) -> None:
+    def test_from_dict_method_with_numpy(
+        self, dict_zeros_numpy_tensor, backend
+    ) -> None:
         """Test the from_dict method with numpy tensors."""
         tensorshare = TensorShare.from_dict(dict_zeros_numpy_tensor, backend=backend)
 
@@ -185,7 +188,9 @@ class TestTensorShare:
 
     @pytest.mark.usefixtures("dict_zeros_paddle_tensor")
     @pytest.mark.parametrize("backend", [None, Backend.PADDLEPADDLE, "paddlepaddle"])
-    def test_from_dict_method_with_paddle(self, dict_zeros_paddle_tensor, backend) -> None:
+    def test_from_dict_method_with_paddle(
+        self, dict_zeros_paddle_tensor, backend
+    ) -> None:
         """Test the from_dict method with paddle tensors."""
         tensorshare = TensorShare.from_dict(dict_zeros_paddle_tensor, backend=backend)
 
@@ -218,7 +223,9 @@ class TestTensorShare:
 
     @pytest.mark.usefixtures("dict_zeros_torch_tensor")
     @pytest.mark.parametrize("backend", [None, Backend.TORCH, "torch"])
-    def test_from_dict_method_with_torch(self, dict_zeros_torch_tensor, backend) -> None:
+    def test_from_dict_method_with_torch(
+        self, dict_zeros_torch_tensor, backend
+    ) -> None:
         """Test the from_dict method with torch tensors."""
         tensorshare = TensorShare.from_dict(dict_zeros_torch_tensor, backend=backend)
 
@@ -236,11 +243,13 @@ class TestTensorShare:
 
     @pytest.mark.usefixtures("serialized_fixed_numpy_tensors")
     @pytest.mark.parametrize("backend", [Backend.FLAX, "flax"])
-    def test_to_tensors_method_with_flax(self, serialized_fixed_numpy_tensors, backend) -> None:
+    def test_to_tensors_method_with_flax(
+        self, serialized_fixed_numpy_tensors, backend
+    ) -> None:
         """Test the to_tensors method with flax backend."""
         tensorshare = TensorShare(
             tensors=serialized_fixed_numpy_tensors,
-            size=len(serialized_fixed_numpy_tensors)
+            size=len(serialized_fixed_numpy_tensors),
         )
         tensors = tensorshare.to_tensors(backend=backend)
 
@@ -250,11 +259,13 @@ class TestTensorShare:
 
     @pytest.mark.usefixtures("serialized_fixed_numpy_tensors")
     @pytest.mark.parametrize("backend", [Backend.NUMPY, "numpy"])
-    def test_to_tensors_method_with_numpy(self, serialized_fixed_numpy_tensors, backend) -> None:
+    def test_to_tensors_method_with_numpy(
+        self, serialized_fixed_numpy_tensors, backend
+    ) -> None:
         """Test the to_tensors method with numpy backend."""
         tensorshare = TensorShare(
             tensors=serialized_fixed_numpy_tensors,
-            size=len(serialized_fixed_numpy_tensors)
+            size=len(serialized_fixed_numpy_tensors),
         )
         tensors = tensorshare.to_tensors(backend=backend)
 
@@ -264,11 +275,13 @@ class TestTensorShare:
 
     @pytest.mark.usefixtures("serialized_fixed_numpy_tensors")
     @pytest.mark.parametrize("backend", [Backend.PADDLEPADDLE, "paddlepaddle"])
-    def test_to_tensors_method_with_paddle(self, serialized_fixed_numpy_tensors, backend) -> None:
+    def test_to_tensors_method_with_paddle(
+        self, serialized_fixed_numpy_tensors, backend
+    ) -> None:
         """Test the to_tensors method with paddle backend."""
         tensorshare = TensorShare(
             tensors=serialized_fixed_numpy_tensors,
-            size=len(serialized_fixed_numpy_tensors)
+            size=len(serialized_fixed_numpy_tensors),
         )
         tensors = tensorshare.to_tensors(backend=backend)
 
@@ -292,11 +305,13 @@ class TestTensorShare:
 
     @pytest.mark.usefixtures("serialized_fixed_numpy_tensors")
     @pytest.mark.parametrize("backend", [Backend.TORCH, "torch"])
-    def test_to_tensors_method_with_torch(self, serialized_fixed_numpy_tensors, backend) -> None:
+    def test_to_tensors_method_with_torch(
+        self, serialized_fixed_numpy_tensors, backend
+    ) -> None:
         """Test the to_tensors method with torch backend."""
         tensorshare = TensorShare(
             tensors=serialized_fixed_numpy_tensors,
-            size=len(serialized_fixed_numpy_tensors)
+            size=len(serialized_fixed_numpy_tensors),
         )
         tensors = tensorshare.to_tensors(backend=backend)
 


### PR DESCRIPTION
This PR:
* Change `from_dict` to a `classmethod` instead of `staticmethod`
* Add a `to_tensors` method to deserialize tensors to a specific backend